### PR TITLE
chore: release v1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.2.2] - 2026-03-30
+
+### Added
+
+- Support for MySQL Trilogy adapter, enabling use with `trilogy` gem alongside the default `mysql2` adapter ([#34](https://github.com/vishaltps/solid_queue_monitor/pull/34))
+
 ## [1.2.1] - 2026-03-17
 
 ### Added

--- a/lib/solid_queue_monitor/version.rb
+++ b/lib/solid_queue_monitor/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SolidQueueMonitor
-  VERSION = '1.2.1'
+  VERSION = '1.2.2'
 end


### PR DESCRIPTION
## Summary

- Bump version to 1.2.2
- Update CHANGELOG with MySQL Trilogy adapter support (#34)

## Changes

- `lib/solid_queue_monitor/version.rb` — version bump to 1.2.2
- `CHANGELOG.md` — add 1.2.2 entry