### PR TITLE
chore: bump version to 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [2.2.0] - 2026-06-24
 
 ### Added
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    solid_queue_monitor (2.1.0)
+    solid_queue_monitor (2.2.0)
       rails (>= 7.0)
       solid_queue (>= 0.1.0)
 

--- a/lib/solid_queue_monitor/version.rb
+++ b/lib/solid_queue_monitor/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SolidQueueMonitor
-  VERSION = '2.1.0'
+  VERSION = '2.2.0'
 end


### PR DESCRIPTION
Bumps the gem to **2.2.0** for the opt-in CSRF protection feature (#40).

### Changes
- `lib/solid_queue_monitor/version.rb`: `2.1.0` → `2.2.0`
- `CHANGELOG.md`: folded the `[Unreleased]` section into `## [2.2.0] - 2026-06-24`

Minor bump — adds the backward-compatible `csrf_protection_enabled` config (default `false`); no breaking changes.

After merge: push the gem to RubyGems and create the `v2.2.0` tag + GitHub release.