### PR TITLE
fix: detect chart SQL dialect from queue connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Activity chart no longer crashes the dashboard on multi-database setups where Solid Queue runs on a different engine than the host app's primary database (e.g. a MySQL primary with a dedicated PostgreSQL queue database via `config.solid_queue.connects_to`). The SQL dialect for the time-bucketing query is now detected from the Solid Queue model's own connection instead of `ActiveRecord::Base`, so a `PG::UndefinedFunction: function unix_timestamp(...) does not exist` error is no longer raised. Single-database and same-engine setups are unaffected. (#42)
+
 ## [2.2.0] - 2026-06-24
 
 ### Added

--- a/app/services/solid_queue_monitor/chart_data_service.rb
+++ b/app/services/solid_queue_monitor/chart_data_service.rb
@@ -61,7 +61,7 @@ module SolidQueueMonitor
     # This works identically on PostgreSQL and SQLite.
     def bucket_counts(model, column, start_time, end_time, interval, exclude_nil: false)
       start_epoch = start_time.to_i
-      expr = bucket_index_expr(column, start_epoch, interval)
+      expr = bucket_index_expr(model, column, start_epoch, interval)
 
       scope = model.where(column => start_time..end_time)
       scope = scope.where.not(column => nil) if exclude_nil
@@ -82,18 +82,23 @@ module SolidQueueMonitor
     # PostgreSQL: CAST((EXTRACT(EPOCH FROM col) - start) / interval AS INTEGER)
     # SQLite:     CAST((CAST(strftime('%s', col) AS INTEGER) - start) / interval AS INTEGER)
     # MySQL:      CAST((UNIX_TIMESTAMP(col) - start) / interval AS SIGNED)
-    def bucket_index_expr(column, start_epoch, interval_seconds)
-      if adapter?('sqlite')
+    #
+    # The adapter is detected from the model's own connection, not
+    # ActiveRecord::Base's. Solid Queue is commonly hosted on a dedicated
+    # database (config.solid_queue.connects_to), which may use a different
+    # engine than the host app's primary connection.
+    def bucket_index_expr(model, column, start_epoch, interval_seconds)
+      if adapter?(model, 'sqlite')
         "CAST((CAST(strftime('%s', #{column}) AS INTEGER) - #{start_epoch}) / #{interval_seconds} AS INTEGER)"
-      elsif adapter?('mysql') || adapter?('trilogy')
+      elsif adapter?(model, 'mysql') || adapter?(model, 'trilogy')
         "FLOOR((UNIX_TIMESTAMP(#{column}) - #{start_epoch}) / #{interval_seconds})"
       else
         "FLOOR((EXTRACT(EPOCH FROM #{column}) - #{start_epoch}) / #{interval_seconds})::integer"
       end
     end
 
-    def adapter?(name)
-      ActiveRecord::Base.connection.adapter_name.downcase.include?(name)
+    def adapter?(model, name)
+      model.connection.adapter_name.downcase.include?(name)
     end
   end
 end

--- a/spec/services/solid_queue_monitor/chart_data_service_spec.rb
+++ b/spec/services/solid_queue_monitor/chart_data_service_spec.rb
@@ -134,6 +134,53 @@ RSpec.describe SolidQueueMonitor::ChartDataService do
     end
   end
 
+  describe 'database adapter detection (multi-database safety)' do
+    let(:service) { described_class.new }
+
+    # Builds the bucket-index SQL for a model whose connection reports the given
+    # adapter, independent of the test database engine.
+    def expr_for(adapter_name)
+      connection = instance_double(ActiveRecord::ConnectionAdapters::AbstractAdapter,
+                                   adapter_name: adapter_name)
+      model = class_double(SolidQueue::Job, connection: connection)
+      service.send(:bucket_index_expr, model, 'created_at', 1000, 3600)
+    end
+
+    it 'uses PostgreSQL EXTRACT(EPOCH ...) syntax for a Postgres connection' do
+      expect(expr_for('PostgreSQL'))
+        .to eq('FLOOR((EXTRACT(EPOCH FROM created_at) - 1000) / 3600)::integer')
+    end
+
+    it 'uses MySQL UNIX_TIMESTAMP syntax for a MySQL connection' do
+      expect(expr_for('Mysql2')).to include('UNIX_TIMESTAMP(created_at)')
+    end
+
+    it 'uses MySQL syntax for a Trilogy connection' do
+      expect(expr_for('Trilogy')).to include('UNIX_TIMESTAMP(created_at)')
+    end
+
+    it 'uses SQLite strftime syntax for a SQLite connection' do
+      expect(expr_for('SQLite')).to include("strftime('%s', created_at)")
+    end
+
+    context 'when Solid Queue runs on a different engine than the primary database' do
+      # Regression for issue #42: MySQL primary + dedicated PostgreSQL queue
+      # database (config.solid_queue.connects_to). The dialect must follow the
+      # Solid Queue model's connection, not ActiveRecord::Base's.
+      before do
+        primary = instance_double(ActiveRecord::ConnectionAdapters::AbstractAdapter,
+                                  adapter_name: 'Mysql2')
+        allow(ActiveRecord::Base).to receive(:connection).and_return(primary)
+      end
+
+      it 'builds Postgres SQL when the queue model is on Postgres' do
+        expr = expr_for('PostgreSQL')
+        expect(expr).to include('EXTRACT(EPOCH FROM created_at)')
+        expect(expr).not_to include('UNIX_TIMESTAMP')
+      end
+    end
+  end
+
   describe 'constants' do
     it 'defines all time ranges' do
       expect(described_class::TIME_RANGES.keys).to eq(%w[15m 30m 1h 3h 6h 12h 1d 3d 1w])


### PR DESCRIPTION
## Summary
- Fixes the activity chart 500ing the dashboard on multi-database setups where Solid Queue runs on a different database engine than the host app's primary connection.
- Detects the SQL dialect from the Solid Queue model's own connection instead of `ActiveRecord::Base`.

## Problem
On a multi-database app with a MySQL primary and a dedicated PostgreSQL queue database (`config.solid_queue.connects_to = { database: { writing: :queue } }`), the chart's time-bucketing query raised:

```
PG::UndefinedFunction: ERROR: function unix_timestamp(timestamp without time zone) does not exist
SELECT FLOOR((UNIX_TIMESTAMP(created_at) - ...) / 3600) ...
```

`ChartDataService#adapter?` picked the SQL dialect from `ActiveRecord::Base.connection` — the **primary** (MySQL) database — so it emitted MySQL `UNIX_TIMESTAMP()` SQL and then executed it against the **Postgres** queue database. Because `show_chart` defaults to `true` and the chart data is computed inline in `OverviewController#index` with no rescue, this took down the entire dashboard page for affected users, not just the chart.

Fixes #42.

## Solution
Detect the adapter from the model's own connection (`SolidQueue::Job.connection`), which is the connection the query actually runs on. The `model` is threaded through `bucket_index_expr` into `adapter?`.

For single-database apps and same-engine multi-database apps, `SolidQueue::Job.connection` resolves to the same adapter as `ActiveRecord::Base.connection`, so the generated SQL is byte-identical — no behavioral change. Only the previously-crashing mixed-engine path changes.

## Changes
- `app/services/solid_queue_monitor/chart_data_service.rb`: `adapter?(model, name)` reads `model.connection.adapter_name`; `bucket_index_expr` takes the model.
- `spec/services/solid_queue_monitor/chart_data_service_spec.rb`: new adapter-detection specs per engine (Postgres / MySQL / Trilogy / SQLite) plus a regression case reproducing #42 (MySQL primary + Postgres queue model → asserts `EXTRACT(EPOCH ...)`, never `UNIX_TIMESTAMP`).
- `CHANGELOG.md`: `[Unreleased] → Fixed` entry.

## Testing
- [x] Unit tests added (adapter detection + #42 regression)
- [x] Full suite green: `346 examples, 0 failures`
- [x] `bundle exec rubocop` clean on changed files
- [x] `spec/requests/solid_queue_monitor/csp_compatibility_spec.rb` passes
- [x] Edge cases considered (single-DB and same-engine multi-DB produce identical SQL)

## Backward compatibility
Fully backward compatible. Safe to ship as a patch release (2.2.1) — no config, no migration.

## Checklist
- [x] Code follows project patterns
- [x] Self-review completed
- [x] Tests pass
- [x] No debug statements left