### PR TITLE
chore: bump version to 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [2.2.1] - 2026-07-13
 
 ### Fixed
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    solid_queue_monitor (2.2.0)
+    solid_queue_monitor (2.2.1)
       rails (>= 7.0)
       solid_queue (>= 0.1.0)
 

--- a/lib/solid_queue_monitor/version.rb
+++ b/lib/solid_queue_monitor/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SolidQueueMonitor
-  VERSION = '2.2.0'
+  VERSION = '2.2.1'
 end


### PR DESCRIPTION
## Summary
Release prep for **v2.2.1** — a patch release shipping the multi-database chart fix from #43.

## Changes
- `lib/solid_queue_monitor/version.rb`: `2.2.0` → `2.2.1`
- `CHANGELOG.md`: promote `[Unreleased]` → `[2.2.1] - 2026-07-13`
- `Gemfile.lock`: refresh `solid_queue_monitor` pin to 2.2.1 (keeps CI's frozen `bundle install` green)

## Included since 2.2.0
- fix: activity chart no longer crashes the dashboard on multi-database setups where Solid Queue runs on a different engine than the primary database (#42, #43)

## Testing
- [x] `bundle install` succeeds and updates the lockfile to 2.2.1
- [x] Full suite green as of #43

## Checklist
- [x] Version bumped
- [x] CHANGELOG updated with date
- [x] Gemfile.lock updated